### PR TITLE
Dev/5 add gatsby transformer remark

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,5 +2,8 @@ module.exports = {
   siteMetadata: {
     title: `Gatsby Default Starter`,
   },
-  plugins: [`gatsby-plugin-react-helmet`],
+  plugins: [
+    `gatsby-plugin-react-helmet`,
+    `gatsby-plugin-styled-components`,
+  ],
 }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,5 +12,6 @@ module.exports = {
         path: `${__dirname}/src/`,
       },
     },
+    `gatsby-transformer-remark`,
   ],
 }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,5 +5,12 @@ module.exports = {
   plugins: [
     `gatsby-plugin-react-helmet`,
     `gatsby-plugin-styled-components`,
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `src`,
+        path: `${__dirname}/src/`,
+      },
+    },
   ],
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "gatsby-link": "^1.6.30",
     "gatsby-plugin-react-helmet": "^1.0.8",
     "gatsby-plugin-styled-components": "^2.0.4",
+    "gatsby-source-filesystem": "^1.5.10",
     "styled-components": "^2.2.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "gatsby-plugin-react-helmet": "^1.0.8",
     "gatsby-plugin-styled-components": "^2.0.4",
     "gatsby-source-filesystem": "^1.5.10",
+    "gatsby-transformer-remark": "^1.7.24",
     "styled-components": "^2.2.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "gatsby": "^1.9.127",
     "gatsby-link": "^1.6.30",
     "gatsby-plugin-react-helmet": "^1.0.8",
+    "gatsby-plugin-styled-components": "^2.0.4",
     "styled-components": "^2.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
add pkg `gatsby-transformer-remark` and corresponding changes to `gatsby.config.js`.

P.S. Everything works together. I tested through _WebGL tool_ for *gatsby*. 
`remark` starts to be available when you add `.md` file to `\pages`.  